### PR TITLE
Infosec overview document

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,6 +88,7 @@ Round
 
    openfl
    fx
+   infosec-orverview
    troubleshooting
 
 .. toctree::

--- a/docs/infosec-orverview.md
+++ b/docs/infosec-orverview.md
@@ -1,8 +1,10 @@
-## Purpose of this document
+# InfoSec Overview
+
+## Purpose
 This document provides the information needed when evaluating OpenFL for real world deployment in highly sensitive environments. The target audience is InfoSec reviewers who need detailed information about code contents, communication traffic, and potential exploit vectors.
 
 ## Network Connectivity Overview
-OpenFL federations use a hub-and-spoke topology between _collaborator_ clients that generate model parameter updates from their data and the _aggregator_ server that combines their training updates into new models. Key details about this functionality are:
+OpenFL federations use a hub-and-spoke topology between _collaborator_ clients that generate model parameter updates from their data and the _aggregator_ server that combines their training updates into new models [[ref](https://openfl.readthedocs.io/en/latest/about/features_index/taskrunner.html)]. Key details about this functionality are:
 * Connections are made using request/response gRPC connections [[ref](https://grpc.io/docs/what-is-grpc/core-concepts/)].
 * The _aggregator_ listens for connections on a single port (usually decided by the experiment admin), and is explicitly defined in the FL plan (f.e. `50051`), so all _collaborators_ must be able to send outgoing traffic to this port.
 * All connections are initiated by the _collaborator_, i.e., a `pull` architecture [[ref](https://karlchris.github.io/data-engineering/data-ingestion/push-pull/#pull)].
@@ -23,7 +25,7 @@ Key points about the network messages/protocol:
 * No executable code is ever sent to the collaborator. All code to be executed is contained within the OpenFL package and the custom FL workspace. The code, along with the FL plan file that specifies the classes and initial parameters to be used, is available for review prior to the FL plans execution. This ensures that all potential operations are understood before they take place.
 * The _collaborator_ typically requests the FL tasks to execute from the aggregator via the `GetTasksRequest` message [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto#L34)]
 * The _aggregator_ reads the FL plan and returns a `GetTasksResponse` [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto#L45)] which includes metadata (`Tasks`) [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto#L38)] about the Python functions to be invoked by the collaborator (the code being installed locally as part of a pre-distributed workspace bundle)
-* The _collaborator_ then uses its TaskRunner framework [[ref](https://openfl.readthedocs.io/en/latest/about/features_index/taskrunner.html)] to execute the FL tasks on the locally available data, producing output tensors such as model weights or metrics
+* The _collaborator_ then uses its TaskRunner framework to execute the FL tasks on the locally available data, producing output tensors such as model weights or metrics
 * During task execution, the _collaborator_ may additionally request tensors from the aggregator via the `GetAggregatedTensor` RPC method [[ref](https://openfl.readthedocs.io/en/latest/reference/_autosummary/openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.html#openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.GetAggregatedTensor)]
 * Upon task completion, the _collaborator_ transmits the results by emitting a `SendLocalTaskResults` call [[ref](https://openfl.readthedocs.io/en/latest/reference/_autosummary/openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.html#openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.SendLocalTaskResults)] which contains `NamedTensor` [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/base.proto#L11)] objects that encode model weight updates or ML metrics such as loss or accuracy (among others).
 

--- a/infosec-orverview.md
+++ b/infosec-orverview.md
@@ -1,0 +1,29 @@
+### Purpose of this document
+This document is intended to help InfoSec analysis processes of the collaborators involved in the initial stages of OpenFL federations by summarizing key points of the code functionality.
+
+#### Network Connectivity Overview
+OpenFL federations use a hub-and-spoke topology between _collaborator_ clients that generate model parameter updates from their data and the _aggregator_ server that combines their training updates into new models. Key details about this functionality are:
+* Connections are made using request/response gRPC connections.
+* The _aggregator_ listens for connections on a single port, explicitly defined in the FL plan (f.e. 50051), so all _collaborators_ must be able to send outgoing traffic to this port.
+* All connections are initiated by the _collaborator_.
+* The _collaborator_ does not open any listening sockets.
+* Connections are secured using mutually-authenticated TLS.
+* Each request response pair is done on a new TLS connection.
+* The PKI for OpenFL federations can be created using openssl tools, with the organization hosting the _aggregator_ usually acting as the Certificate Authority (CA) that verifies each identity before signing.
+* Currently, the _collaborator_ polls the _aggregator_ at a fixed interval. We have had a request to enable client-side configuration of this interval and hope to support that feature soon.
+* Connection timeouts are set to gRPC defaults.
+* If the _aggregator_ is not available, the _collaborator_ will retry connections indefinitely. This is currently useful so that we can take the aggregator down for bugfixes without _collaborator_ processes exiting.
+
+#### Overview of Contents of Network Messages
+Network messages are well defined protobufs which can be found in [aggregator.proto](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto) and [base.proto](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/base.proto).
+Key points about the network messages/protocol:
+* No private data is ever sent to the _aggregator_
+* No executable code is ever sent to the _collaborator_. All algorithms come with the OpenFL package and the custom FL workspace.
+* The _collaborator_ typically requests the FL tasks to execute from the aggregator via the `GetTasksRequest` message
+* The _aggregator_ reads the FL plan and returns a `GetTasksResponse` which includes metadata (`Tasks`) about the Python functions to be invoked by the collaborator (the code being installed locally as part of a pre-distributed workspace bundle)
+* The _collaborator_ then uses its TaskRunner framework to execute the FL tasks on the locally available data, producing output tensors such as model weights or metrics
+* During task execution, the _collaborator_ may additionally request tensors from the aggregator via the `GetAggregatedTensor` RPC method
+* Upon task completion, the _collaborator_ transmits the results by emitting a `SendLocalTaskResults` call which contains `NamedTensor` objects that encode model weight updates or ML metrics such as loss or accuracy (among others).
+
+#### Testing a Collaborator
+In order to test a _collaborator_, the _aggregator_ can be set to not aggregate updates from specific _collaborators_ so that they can test functionality without impacting the running model training/validation. We hope this enables InfoSec runtime analysis against the live _aggregator_ without the need to access any private data on the _collaborator_ machine running the test. To do this, please coordinate with the OpenFL aggregator admins.

--- a/infosec-orverview.md
+++ b/infosec-orverview.md
@@ -1,29 +1,31 @@
-### Purpose of this document
-This document is intended to help InfoSec analysis processes of the collaborators involved in the initial stages of OpenFL federations by summarizing key points of the code functionality.
+## Purpose of this document
+This document provides the information needed when evaluating OpenFL for real world deployment in highly sensitive environments. The target audience is InfoSec reviewers who need detailed information about code contents, communication traffic, and potential exploit vectors.
 
-#### Network Connectivity Overview
+## Network Connectivity Overview
 OpenFL federations use a hub-and-spoke topology between _collaborator_ clients that generate model parameter updates from their data and the _aggregator_ server that combines their training updates into new models. Key details about this functionality are:
-* Connections are made using request/response gRPC connections.
-* The _aggregator_ listens for connections on a single port, explicitly defined in the FL plan (f.e. 50051), so all _collaborators_ must be able to send outgoing traffic to this port.
-* All connections are initiated by the _collaborator_.
+* Connections are made using request/response gRPC connections [[ref](https://grpc.io/docs/what-is-grpc/core-concepts/)].
+* The _aggregator_ listens for connections on a single port (usually decided by the experiment admin), and is explicitly defined in the FL plan (f.e. `50051`), so all _collaborators_ must be able to send outgoing traffic to this port.
+* All connections are initiated by the _collaborator_, i.e., a `pull` architecture [[ref](https://karlchris.github.io/data-engineering/data-ingestion/push-pull/#pull)].
 * The _collaborator_ does not open any listening sockets.
-* Connections are secured using mutually-authenticated TLS.
+* Connections are secured using mutually-authenticated TLS [[ref](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/)].
 * Each request response pair is done on a new TLS connection.
-* The PKI for OpenFL federations can be created using openssl tools, with the organization hosting the _aggregator_ usually acting as the Certificate Authority (CA) that verifies each identity before signing.
+* The PKI for federations can be created using the [OpenFL CLI](https://openfl.readthedocs.io/en/latest/about/features_index/taskrunner.html#step-2-configure-the-federation). OpenFL internally leverages Python's cryptography module. The organization hosting the _aggregator_ usually acts as the Certificate Authority (CA) and verifies each identity before signing.
 * Currently, the _collaborator_ polls the _aggregator_ at a fixed interval. We have had a request to enable client-side configuration of this interval and hope to support that feature soon.
 * Connection timeouts are set to gRPC defaults.
 * If the _aggregator_ is not available, the _collaborator_ will retry connections indefinitely. This is currently useful so that we can take the aggregator down for bugfixes without _collaborator_ processes exiting.
 
-#### Overview of Contents of Network Messages
-Network messages are well defined protobufs which can be found in [aggregator.proto](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto) and [base.proto](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/base.proto).
-Key points about the network messages/protocol:
-* No private data is ever sent to the _aggregator_
-* No executable code is ever sent to the _collaborator_. All algorithms come with the OpenFL package and the custom FL workspace.
-* The _collaborator_ typically requests the FL tasks to execute from the aggregator via the `GetTasksRequest` message
-* The _aggregator_ reads the FL plan and returns a `GetTasksResponse` which includes metadata (`Tasks`) about the Python functions to be invoked by the collaborator (the code being installed locally as part of a pre-distributed workspace bundle)
-* The _collaborator_ then uses its TaskRunner framework to execute the FL tasks on the locally available data, producing output tensors such as model weights or metrics
-* During task execution, the _collaborator_ may additionally request tensors from the aggregator via the `GetAggregatedTensor` RPC method
-* Upon task completion, the _collaborator_ transmits the results by emitting a `SendLocalTaskResults` call which contains `NamedTensor` objects that encode model weight updates or ML metrics such as loss or accuracy (among others).
+## Overview of Contents of Network Messages
+Network messages are well defined protobufs which can be found in the following files:
+- [aggregator.proto](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto)
+- [base.proto](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/base.proto)
 
-#### Testing a Collaborator
-In order to test a _collaborator_, the _aggregator_ can be set to not aggregate updates from specific _collaborators_ so that they can test functionality without impacting the running model training/validation. We hope this enables InfoSec runtime analysis against the live _aggregator_ without the need to access any private data on the _collaborator_ machine running the test. To do this, please coordinate with the OpenFL aggregator admins.
+Key points about the network messages/protocol:
+* No executable code is ever sent to the collaborator. All code to be executed is contained within the OpenFL package and the custom FL workspace. The code, along with the FL plan file that specifies the classes and initial parameters to be used, is available for review prior to the FL plans execution. This ensures that all potential operations are understood before they take place.
+* The _collaborator_ typically requests the FL tasks to execute from the aggregator via the `GetTasksRequest` message [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto#L34)]
+* The _aggregator_ reads the FL plan and returns a `GetTasksResponse` [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto#L45)] which includes metadata (`Tasks`) [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/aggregator.proto#L38)] about the Python functions to be invoked by the collaborator (the code being installed locally as part of a pre-distributed workspace bundle)
+* The _collaborator_ then uses its TaskRunner framework [[ref](https://openfl.readthedocs.io/en/latest/about/features_index/taskrunner.html)] to execute the FL tasks on the locally available data, producing output tensors such as model weights or metrics
+* During task execution, the _collaborator_ may additionally request tensors from the aggregator via the `GetAggregatedTensor` RPC method [[ref](https://openfl.readthedocs.io/en/latest/reference/_autosummary/openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.html#openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.GetAggregatedTensor)]
+* Upon task completion, the _collaborator_ transmits the results by emitting a `SendLocalTaskResults` call [[ref](https://openfl.readthedocs.io/en/latest/reference/_autosummary/openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.html#openfl.transport.grpc.aggregator_server.AggregatorGRPCServer.SendLocalTaskResults)] which contains `NamedTensor` [[ref](https://github.com/securefederatedai/openfl/blob/develop/openfl/protocols/base.proto#L11)] objects that encode model weight updates or ML metrics such as loss or accuracy (among others).
+
+## Testing a Collaborator
+There is a "no-op" workspace template in OpenFL (available in versions `>=1.9`) which can be used to test the network connection between the _aggregator_ and each _collaborator_ without performing any computational task. More details can be found [here](https://github.com/securefederatedai/openfl/tree/develop/openfl-workspace/no-op#overview).


### PR DESCRIPTION
## Summary
Initializing an "infosec overview" document to help collaborators with their security review when joining an OpenFL-based federation

## Type of Change (Mandatory)
- Documentation update  

## Description (Mandatory)
This document is a generalization of the infosec overview for the FeTS initiative. It has been adapted to follow the current patterns in the OpenFL (TaskRunner API) code.

## Testing
N/A